### PR TITLE
fix(output): prevent Zip Slip in unzip_file (CWE-22)

### DIFF
--- a/botasaurus/output.py
+++ b/botasaurus/output.py
@@ -530,6 +530,57 @@ def _has_0_item(path):
     
     return True
 
+def _safe_extractall(zipf, output_folder_path):
+    """
+    Safely extract a zip archive to ``output_folder_path``, defending against
+    Zip Slip (CWE-22).
+
+    ``ZipFile.extractall`` on modern CPython strips leading ``/`` and ``..``
+    components from member names, but it does *not* prevent an entry from
+    being written *through* a pre-existing symlink inside the extraction
+    directory that points outside it. For each member we therefore resolve
+    the intended destination with ``os.path.realpath`` and refuse to extract
+    any entry whose resolved path escapes the (resolved) extraction dir.
+    """
+    import posixpath
+
+    resolved_base = os.path.realpath(output_folder_path)
+    for member in zipf.infolist():
+        # Normalise the archive-supplied name: forward-slash separated,
+        # drop drive letters, and split into path components.
+        name = member.filename.replace('\\', '/')
+        name = os.path.splitdrive(name)[1]
+        parts = [p for p in name.split('/') if p not in ('', '.')]
+        # Reject any '..' component outright.
+        if any(p == '..' for p in parts):
+            raise ValueError(
+                "Refusing to extract unsafe zip entry "
+                "(parent traversal): {!r}".format(member.filename)
+            )
+        safe_relative = posixpath.join(*parts) if parts else ''
+        if not safe_relative:
+            # Directory-only or empty entry after sanitisation; skip.
+            continue
+        target_path = os.path.realpath(
+            os.path.join(resolved_base, safe_relative)
+        )
+        # commonpath raises on mixed drives; treat any anomaly as escape.
+        try:
+            common = os.path.commonpath([resolved_base, target_path])
+        except ValueError:
+            common = None
+        if common != resolved_base:
+            raise ValueError(
+                "Refusing to extract unsafe zip entry "
+                "(escapes target dir): {!r}".format(member.filename)
+            )
+        # Rewrite the member filename to the sanitised, validated form
+        # so extract() writes to the checked location and cannot re-follow
+        # any pre-existing symlink under the original arcname.
+        member.filename = safe_relative
+        zipf.extract(member, resolved_base)
+
+
 def unzip_file(filename, output_folder_path=None, force=False, log=True):
     import zipfile
     import shutil
@@ -574,7 +625,7 @@ def unzip_file(filename, output_folder_path=None, force=False, log=True):
         os.makedirs(output_folder_path, exist_ok=True)
 
         with zipfile.ZipFile(filename, 'r') as zipf:
-            zipf.extractall(output_folder_path)
+            _safe_extractall(zipf, output_folder_path)
 
 
         folder_in_folder = os.path.join(output_folder_path, os.path.basename(output_folder_path))


### PR DESCRIPTION
## Summary

`botasaurus.output.unzip_file` (re-exported as `botasaurus.bt.unzip_file`) is a Zip Slip sink (CWE-22 — Path Traversal). It calls `zipfile.ZipFile.extractall(output_folder_path)` directly on the caller-supplied archive with no per-entry destination validation. When the extraction folder contains (or already contained) a symlink whose name matches a prefix in an entry, extraction writes the entry *through* the symlink and lands outside `output_folder_path`.

Modern CPython does strip leading `/` and literal `..` components from entry names, but it does **not** refuse to write through a pre-existing symlink inside the extraction directory. That is the escape path exploited below.

- **CWE:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory / Zip Slip)
- **Severity:** Medium — the helper is a public library API used by downstream scrapers that routinely feed it network-downloaded archives; exploitability depends on the caller passing an untrusted zip.
- **Affected function:** `unzip_file` in `botasaurus/output.py` (line 584), also exposed as `botasaurus.bt.unzip_file` (`botasaurus/bt.py:30`).
- **Data flow:** `unzip_file(filename, output_folder_path)` → `zipfile.ZipFile(filename, 'r').extractall(output_folder_path)`. No entry-name sanitisation between the two.

## Fix

Introduce a small `_safe_extractall(zipf, output_folder_path)` helper and call it in place of `zipf.extractall(...)`. For each member the helper:

1. Normalises the entry name (forward slashes, strip drive letter, drop empty / `.` components).
2. Rejects any entry containing a literal `..` component with a clear `ValueError`.
3. Resolves the intended target with `os.path.realpath(os.path.join(resolved_base, safe_relative))` and requires `os.path.commonpath([resolved_base, target_path]) == resolved_base`. This catches the pre-existing-symlink case because `realpath` follows the symlink before the containment check.
4. **Rewrites `member.filename` to the sanitised, validated form** before calling `zipf.extract(member, resolved_base)`. This is important: passing the original arcname to `extract()` would re-follow the symlink component we just validated away. Rewriting to the sanitised relative path means the actual write goes to the checked location.

The public `unzip_file` API and its existing `try/except` are unchanged — a malicious archive is caught by `except Exception as e: print("Error while unzipping file: ...")` and the function returns `None`, matching the existing failure contract (invalid zip, missing file, etc.). No new dependencies. Diff is one file, +52/-1.

## Test results

Reproduced with a short script against the current `master` and the fix branch. Both runs use the same PoC archive.

Pre-fix (unchanged `zipf.extractall`):

```
outside contents (pre-fix): ['pwned.txt']
PRE-FIX: attacker file written OUTSIDE outdir — vulnerability confirmed
   contents: OWNED
```

Post-fix (`_safe_extractall`):

```
Error while unzipping file: Refusing to extract unsafe zip entry (escapes target dir): 'link/pwned.txt'
unzip_file returned: None
outside contents: []
OK: post-fix blocks the symlink-based zip slip
```

Additional post-fix checks:

- Benign nested archive (`inner/a.txt`, `inner/sub/b.txt`) still extracts to the expected relative paths — the fix does not regress happy-path behaviour.
- A raw `../pwned.txt` entry (constructed via `ZipInfo` so CPython does not pre-strip) is rejected with `Refusing to extract unsafe zip entry (parent traversal)` and no file is written outside the target directory.

## Security analysis

Why this is exploitable in practice:

- `unzip_file` is a re-exported public helper (`from botasaurus.output import unzip_file` at `botasaurus/bt.py:30`), so any downstream scraper that fetches a zip from a target site (or a user-supplied URL) and calls `bt.unzip_file(...)` inherits the sink.
- The escape requires only that the extraction folder contains a symlink whose name matches a prefix inside the archive. This can arise from (a) a previous extraction into the same folder, (b) the caller reusing a scratch directory that already contains developer-created symlinks, or (c) an attacker who influenced an earlier archive extracted to the same location.
- CPython's built-in `extractall` sanitisation is not sufficient here — that layer only rewrites the entry name; it does not `realpath`-check the destination before opening the output file, so writes through a symlink land wherever the link points.

What the fix provides:

- Per-entry containment check against `realpath(output_folder_path)` after `realpath`-resolving the target, which catches both `..` traversal and pre-existing symlink escapes.
- Refuses any entry with a literal `..` component before even resolving the target, so error messages are actionable.
- Rewriting `member.filename` before `extract` closes the second-order case where the sanitised path is validated but the original arcname (still containing the symlinked prefix) would otherwise be used by `extract()`.

Preconditions for exploitation:

- A caller passes an attacker-influenced zip to `unzip_file` / `bt.unzip_file`.
- The extraction directory already contains a symlink component (or the attacker gets a `..` entry past CPython's own filtering — the fix defends against both).

Scope note: there is a separate `extractall` call in `bota/src/bota/vm.py:162`. That path is a CLI tool that only extracts an archive downloaded from a fixed, developer-controlled release URL and is intentionally out of scope for this PR to keep the diff minimal.

## Proof of concept

Save as `poc_zipslip.py` at the repo root and run with `python3 poc_zipslip.py` (Linux/macOS; requires symlink support). It reproduces the escape against the pre-fix helper and verifies containment against the post-fix helper.

```python
import os, shutil, sys, tempfile, zipfile
sys.path.insert(0, '.')
from botasaurus.output import unzip_file

tmp = tempfile.mkdtemp()
try:
    outside = os.path.join(tmp, 'outside')
    outdir = os.path.join(tmp, 'out')
    os.makedirs(outside)
    os.makedirs(outdir)
    # Pre-existing symlink inside the extraction dir pointing outside it.
    os.symlink(outside, os.path.join(outdir, 'link'))

    # Malicious archive: entry named 'link/pwned.txt' — CPython's own
    # extractall sanitisation does NOT strip this because it does not
    # contain '..'; the write follows the symlink.
    zpath = os.path.join(tmp, 'evil.zip')
    with zipfile.ZipFile(zpath, 'w') as z:
        z.writestr('link/pwned.txt', 'OWNED')

    unzip_file(zpath, outdir, force=True, log=False)

    escaped = os.listdir(outside)
    print('outside contents:', escaped)
    if 'pwned.txt' in escaped:
        print('VULNERABLE: attacker file written outside outdir')
    else:
        print('SAFE: extraction was contained')
finally:
    shutil.rmtree(tmp, ignore_errors=True)
```

Expected output on `master`:

```
outside contents: ['pwned.txt']
VULNERABLE: attacker file written outside outdir
```

Expected output on this branch:

```
Error while unzipping file: Refusing to extract unsafe zip entry (escapes target dir): 'link/pwned.txt'
outside contents: []
SAFE: extraction was contained
```

## Adversarial review

Before submitting, I tried to disprove this finding. Three angles worth calling out:

1. *Does CPython's own `extractall` already prevent this?* Only partially. It rewrites entry names to strip `/` prefixes and `..` components, but it does not `realpath`-check the destination, so writes through a pre-existing symlink inside the target dir are not blocked — the PoC above demonstrates this directly on the current `master`.
2. *Is there any in-repo HTTP route that pipes attacker data into `unzip_file`?* No — I grep'd, and there isn't one today. This is why I've rated it medium, not high: the exposure is through downstream library consumers, which for a 5.5k-star scraping framework re-exporting the helper as `bt.unzip_file` is a realistic-enough surface to be worth hardening.
3. *Is the fix itself safe / non-regressing?* The helper mirrors the pattern used by other Zip Slip mitigations (per-member `realpath` + `commonpath` containment, then rewrite `member.filename` before `extract`). Benign nested archives round-trip identically; the `try/except` in `unzip_file` already handles the raised `ValueError` and returns `None`, matching the existing failure contract.

Happy to iterate on wording, error type, or scope if you'd prefer the helper to live somewhere else in the module.